### PR TITLE
Fix Light/Dark Mode icons to be standard icons

### DIFF
--- a/react/src/components/LibraryNavigation/index.tsx
+++ b/react/src/components/LibraryNavigation/index.tsx
@@ -11,11 +11,11 @@ import {
 } from '@mui/material';
 import {
   AccountCircle,
-  Brightness7,
   ExitToApp,
   Home,
   LocalLibrary,
-  ModeNight,
+  LightMode,
+  DarkMode,
 } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 
@@ -233,7 +233,7 @@ const Navigation = () => {
               style={{ marginInline: 10 }}
               onClick={() => toggleTheme()}
             >
-              {theme.palette.mode === 'dark' ? <Brightness7 /> : <ModeNight />}
+              {theme.palette.mode === 'dark' ? <LightMode /> : <DarkMode />}
             </IconButton>
             {user && <AuthMenuItems />}
             {!user && (


### PR DESCRIPTION
<!--

Thank you for contributing to the BASIS Scottsdale Library! We strongly recommend you open an
issue before creating a pull request. Once you have completed the following, please fill out the pull request form below.

 - [ ] I have read the contributing guidelines
 - [ ] I have read the code of conduct
 - [ ] I have included the following:
    - [ ] A description/summary of the changes
    - [ ] A link to the related issue(s)


-->

Fixes #707

### Description

Replaced old, ambiguous Light/ Dark mode icons with the standard ones nominatively declared in the [Material Icons Browser](https://mui.com/material-ui/material-icons/?query=mode).

