### PR TITLE
Word wrap fixed, but formating now inconsistent

### DIFF
--- a/react/src/pages/CustomPage/About/index.tsx
+++ b/react/src/pages/CustomPage/About/index.tsx
@@ -13,17 +13,10 @@ interface TabPanelProps {
 }
 
 const TabPanel = ({ children, value, index, ...other }: TabPanelProps) => (
-  <div
-    role="tabpanel"
-    hidden={value !== index}
-    style={{ overflowWrap: 'break-word' }}
-    {...other}
-  >
+  <div role="tabpanel" hidden={value !== index} {...other}>
     {value === index && (
       <Box m="5%">
-        <div style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
-          {children}
-        </div>
+        <div style={{ whiteSpace: 'pre-wrap' }}>{children}</div>
       </Box>
     )}
   </div>
@@ -44,7 +37,6 @@ const About = () => {
               value={value}
               onChange={(e, newValue) => setValue(newValue)}
               scrollButtons
-              style={{ overflowWrap: 'anywhere' }}
               allowScrollButtonsMobile
             >
               <Tab wrapped label="Introduction" />

--- a/react/src/pages/CustomPage/Contribute/index.tsx
+++ b/react/src/pages/CustomPage/Contribute/index.tsx
@@ -12,17 +12,10 @@ interface TabPanelProps {
 }
 
 const TabPanel = ({ children, value, index, ...other }: TabPanelProps) => (
-  <div
-    role="tabpanel"
-    hidden={value !== index}
-    style={{ overflowWrap: 'break-word' }}
-    {...other}
-  >
+  <div role="tabpanel" hidden={value !== index} {...other}>
     {value === index && (
       <Box m="5%">
-        <div style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
-          {children}
-        </div>
+        <div style={{ whiteSpace: 'pre-wrap' }}>{children}</div>
       </Box>
     )}
   </div>
@@ -43,7 +36,6 @@ const Contribute = () => {
               value={value}
               onChange={(e, newValue) => setValue(newValue)}
               scrollButtons
-              style={{ overflowWrap: 'anywhere' }}
               allowScrollButtonsMobile
             >
               <Tab wrapped label="Donate" />


### PR DESCRIPTION
<!--

Thank you for contributing to the BASIS Scottsdale Library! We strongly recommend you open an
issue before creating a pull request. Once you have completed the following, please fill out the pull request form below.

 - [ ] I have read the contributing guidelines
 - [ ] I have read the code of conduct
 - [ ] I have included the following:
    - [ ] A description/summary of the changes
    - [ ] A link to the related issue(s)


-->

Fixes #705 

### Description

Solves the text wrap bug, but simultaneously introduces the an issue of inconsistent flexbox sizes across the different subpages.

@epodol asserts this will be irrelevant/ patched in a future update.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. -->

**Comparisons:**

> Side-by-side:
> 
> ![quickFlip](https://user-images.githubusercontent.com/45369057/180590908-e6f3c8e0-28b8-4405-93cf-db7dc3fa47d7.gif)
> 

> About Page `Inspect Element` Metadata:
> ![image](https://user-images.githubusercontent.com/45369057/180590938-c0bfe07a-b8ca-427e-838c-f56db64b8080.png)
> 
> 

> Contribute Page `Inspect Element` Metadata:
> ![image](https://user-images.githubusercontent.com/45369057/180590935-7316578a-8788-4ead-ac02-2635dce81790.png)
> 
> 